### PR TITLE
Update docfx from v2.45.1 --> 2.56.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ ENTRYPOINT [ "docfx" ]
 
 ADD ./entrypoint.sh /usr/local/bin/docfx
 
-ADD https://github.com/dotnet/docfx/releases/download/v2.45.1/docfx.zip /
+ADD https://github.com/dotnet/docfx/releases/download/v2.56.1/docfx.zip /
 RUN unzip docfx.zip -d /docfx && \
     rm docfx.zip


### PR DESCRIPTION
Updates docfx to the lastest release.

I believe this version includes several bugfixes, one of which is related to https://github.com/nunit/docs/issues/448.