### PR TITLE
Update docfx version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ ENTRYPOINT [ "docfx" ]
 
 ADD ./entrypoint.sh /usr/local/bin/docfx
 
-ADD https://github.com/dotnet/docfx/releases/download/v2.45.1/docfx.zip /
+ADD https://github.com/dotnet/docfx/releases/download/v2.56.6/docfx.zip /
 RUN unzip docfx.zip -d /docfx && \
     rm docfx.zip


### PR DESCRIPTION
Hi, I saw this action in a docfx issue https://github.com/dotnet/docfx/issues/3284#issuecomment-655738259 and thought I'd give it  a spin. 

Noticed that it's targeting a lower docfx version than what I use though so would like to update it.